### PR TITLE
Set min-width to prevent shrinking

### DIFF
--- a/apps/gha-web-ui/src/app/active-repositories/active-repositories.smart-component.scss
+++ b/apps/gha-web-ui/src/app/active-repositories/active-repositories.smart-component.scss
@@ -4,6 +4,7 @@
 
 .active-repositories {
   width: fit-content;
+  min-width: 970px;
 }
 
 .repo {


### PR DESCRIPTION
set .active-repositories min-width to 970px to prevent shrinking the content while filtering 