### PR TITLE
use temurin as base image to enable build on M1

### DIFF
--- a/apps/gha-badge-generator/Dockerfile
+++ b/apps/gha-badge-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-jre-jammy
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
# Motivation
Openjdk images are deprecated: https://hub.docker.com/_/openjdk

Moreover, OpenJdk  base image used  is targeted only to amd64 and doesn't build on Apple Silicon (ARM)

# Proposed solution
Move to Temurin base image 
 