### PR TITLE
Allow filtering with multiple terms (separated by spaces).

### DIFF
--- a/apps/gha-web-ui/src/app/repo-filter-pipe/repo-filter.pipe.ts
+++ b/apps/gha-web-ui/src/app/repo-filter-pipe/repo-filter.pipe.ts
@@ -13,8 +13,12 @@ export class RepoFilterPipe implements PipeTransform {
       return repos;
 
     return repos.filter(repo => {
-      return this.matchesFilter(repo, filter.toLowerCase());
+      return this.matchesAllPartsOfFilter(repo, filter.toLowerCase());
     });
+  }
+
+  private matchesAllPartsOfFilter(repo: Repo, filter: string): boolean {
+    return filter.split(' ').every(part => this.matchesFilter(repo, part));
   }
 
   private matchesFilter(repo: Repo, filter: string): boolean {


### PR DESCRIPTION
For example this is really useful if you want to find recent acs-packaging master builds:

![image](https://user-images.githubusercontent.com/11535082/220610179-abceb247-48c4-4482-8d7b-b7618058f50b.png)
